### PR TITLE
Update Grafana package source

### DIFF
--- a/scripts/3-install-grafana.sh
+++ b/scripts/3-install-grafana.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-echo 'deb https://packagecloud.io/grafana/stable/debian/ jessie main' >> /etc/apt/sources.list
-curl https://packagecloud.io/gpg.key | sudo apt-key add -
+echo 'deb https://packages.grafana.com/oss/deb stable main' >> /etc/apt/sources.list
+curl https://packages.grafana.com/gpg.key | sudo apt-key add -
 sudo apt-get update
 sudo apt-get -y install grafana
 


### PR DESCRIPTION
Grafana did update their package location (As here: http://docs.grafana.org/installation/debian/). This commit changes the source location on the install script to fix the errors with the old package.